### PR TITLE
Implement #[interrupt_handler] macro

### DIFF
--- a/cortex-a-rt.x
+++ b/cortex-a-rt.x
@@ -50,6 +50,7 @@ SECTIONS
     __stext = .;
     *(.init1);
     *(.except)
+    *(.weak_default)
 
     *(.text .text.*);
 

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -1,9 +1,5 @@
 #[allow(unused_imports)]
 use core::arch::asm;
-use core::{
-    mem::transmute,
-    sync::atomic::{AtomicUsize, Ordering},
-};
 
 /// Enable IRQs and FIQs on calling CPU.
 ///
@@ -80,19 +76,4 @@ pub fn is_fiq_enabled() -> bool {
     }
     #[cfg(not(armv7a))]
     unimplemented!()
-}
-
-static IRQ_HANDLER: AtomicUsize = AtomicUsize::new(0);
-
-#[no_mangle]
-extern "C" fn __cortex_a_irq_handler() {
-    let handler = IRQ_HANDLER.load(Ordering::Relaxed);
-    if handler != 0 {
-        let handler = unsafe { transmute::<_, fn()>(handler) };
-        handler();
-    }
-}
-
-pub fn install_irq_handler(handler: fn()) {
-    IRQ_HANDLER.store(handler as usize, Ordering::Relaxed);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,13 @@ global_asm! {
         ldmfd sp!, {{r0-r12, pc}}^
     __cortex_a_excp_fiq:
         b .
+
+    .section .weak_default, "ax"
+    .weak __cortex_a_irq_handler
+    .type __cortex_a_irq_handler, #function
+    __cortex_a_irq_handler:
+        bx lr
+    .size __cortex_a_irq_handler, . - __cortex_a_irq_handler
     "#
 }
 


### PR DESCRIPTION
This is new method for registering interrupt handler, now possible at build-time. A no-op weak implementation is provided by default.