### PR TITLE
Add support for log crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
             description: defmt support
           - args: --features=panic_handler,defmt
             description: Panic handler with defmt
+          - args: --features=log
+            description: log crate support
+          - args: --features=panic_handler,log
+            description: Panic handler with log crate
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.target }} on ${{ matrix.os }} (${{ matrix.features.description }})
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 [features]
 single-core-critical-section = ["dep:critical-section"]
 defmt = ["dep:defmt"]
+log = ["dep:log"]
 panic_handler = []
 
 [dependencies]
@@ -23,4 +24,8 @@ features = ["restore-state-u8"]
 
 [dependencies.defmt]
 version = "0.3"
+optional = true
+
+[dependencies.log]
+version = "0.4"
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,18 @@
 #![cfg_attr(not(test), no_std)]
 
+#[cfg(feature = "defmt")]
+#[allow(unused_imports)]
+#[macro_use(error)]
+extern crate defmt;
+
+#[cfg(feature = "log")]
+#[allow(unused_imports)]
+#[macro_use(error)]
+extern crate log;
+
+#[cfg(all(feature = "defmt", feature = "log"))]
+compile_error!("enable either \"defmt\" or \"log\" but not both");
+
 extern crate cortex_a_rt_macros as macros;
 
 #[allow(unused_imports)]

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -6,20 +6,20 @@ extern "C" {
 
 #[panic_handler]
 fn handler(info: &PanicInfo) -> ! {
-    #[cfg(feature = "defmt")]
+    #[cfg(any(feature = "defmt", feature = "log"))]
     {
-        defmt::error!("=== KERNEL PANIC ===");
+        error!("=== KERNEL PANIC ===");
         if let Some(location) = info.location() {
-            defmt::error!(" @ {}:{}", location.file(), location.line());
+            error!(" @ {}:{}", location.file(), location.line());
         } else {
-            defmt::error!(" <location unknown>");
+            error!(" <location unknown>");
         }
 
         if let Some(message) = info.message().as_str() {
-            defmt::error!("Message: {}", message);
+            error!("Message: {}", message);
         }
     }
-    #[cfg(not(feature = "defmt"))]
+    #[cfg(not(any(feature = "defmt", feature = "log")))]
     {
         let _ = info;
     }


### PR DESCRIPTION
In many cases it may be preferred to actually use log crate and thus do all string formatting on the device and send ready text logs through UART which can be processed without any specialized software.

log crate will increase compiled binary size and will incur some (probably unnoticeable on Cortex-A) performance penalties due to string formatting. However, UARTs typically are slow and defmt can give noticeable advantage.